### PR TITLE
etcd: add support for extra key info to watchtree.

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -82,6 +82,11 @@ type Store interface {
 	// a given directory
 	WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*KVPair, error)
 
+	// WatchTreeExt watches for changes on child nodes under
+	// a given directory and provides some extra information
+	// about them.
+	WatchTreeExt(directory string, stopCh <-chan struct{}) (<-chan *KVPairExt, error)
+
 	// NewLock creates a lock for a given key.
 	// The returned Locker is not held and must be acquired
 	// with `.Lock`. The Value is optional.
@@ -109,6 +114,17 @@ type KVPair struct {
 	Key       string
 	Value     []byte
 	LastIndex uint64
+}
+
+// KVPairExt represents  KVPair and some extra
+// information provided by etcd store
+type KVPairExt struct {
+	Key       string
+	Value     string
+	PrevValue string
+	LastIndex uint64
+	Action    string
+	Dir       bool
 }
 
 // WriteOptions contains optional request parameters


### PR DESCRIPTION
etcd: add support for extra key info to watchtree.

WatchTreeExt watches for changes on a "directory",
extended edition. It provides some extra information
along with normal key and value change.
It returns a channel that will receive changes or pass
on errors. Providing a non-nil stopCh can be used to
stop watching.