### PR TITLE
Expose etcd.Response for romana-2.0

### DIFF
--- a/store/etcd/etcd.go
+++ b/store/etcd/etcd.go
@@ -202,6 +202,7 @@ func (s *Etcd) GetExt(key string, options store.GetOptions) (pair *store.KVPairE
 		LastIndex: result.Node.ModifiedIndex,
 		Action:    result.Action,
 		Dir:       result.Node.Dir,
+		Response:  result,
 	}
 
 	return kv, nil
@@ -324,6 +325,7 @@ func (s *Etcd) WatchExt(key string, options store.WatcherOptions, stopCh <-chan 
 				LastIndex: pair.LastIndex,
 				Action:    pair.Action,
 				Dir:       pair.Dir,
+				Response:  pair.Response,
 			}
 		}
 
@@ -353,6 +355,7 @@ func (s *Etcd) WatchExt(key string, options store.WatcherOptions, stopCh <-chan 
 				LastIndex: result.Node.ModifiedIndex,
 				Action:    result.Action,
 				Dir:       result.Node.Dir,
+				Response:  result,
 			}
 		}
 	}()
@@ -450,6 +453,7 @@ func (s *Etcd) WatchTreeExt(directory string, stopCh <-chan struct{}) (<-chan *s
 				LastIndex: result.Node.ModifiedIndex,
 				Action:    result.Action,
 				Dir:       result.Node.Dir,
+				Response:  result,
 			}
 		}
 	}()
@@ -592,6 +596,7 @@ func (s *Etcd) ListExt(directory string) ([]*store.KVPairExt, error) {
 			Value:     n.Value,
 			LastIndex: n.ModifiedIndex,
 			Dir:       n.Dir,
+			Response:  result,
 		})
 	}
 

--- a/store/store.go
+++ b/store/store.go
@@ -4,6 +4,8 @@ import (
 	"crypto/tls"
 	"errors"
 	"time"
+
+	etcd "github.com/coreos/etcd/client"
 )
 
 // Backend represents a KV Store Backend
@@ -134,6 +136,11 @@ type KVPairExt struct {
 	LastIndex uint64
 	Action    string
 	Dir       bool
+	Response  *etcd.Response
+}
+
+func (p *KVPairExt) GetResponse() *etcd.Response {
+	return p.Response
 }
 
 // WatcherOptions represents options that can affect


### PR DESCRIPTION
Existing implementation doesn't expose recursive nature of `etcd.Node` which makes it impossible to watch trees recursively.